### PR TITLE
Use unchecked indexing to gain some speed.

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -25,11 +25,13 @@ use test::{Bencher, black_box};
 fn complex(size: usize, bencher: &mut Bencher) {
     let mut data = vec![c64::new(42.0, 69.0); size];
     let plan = Plan::new(Operation::Forward, size);
+    bencher.bytes = size as u64;
     bencher.iter(|| black_box(dft::transform(&mut data, &plan)));
 }
 
 fn real(size: usize, bencher: &mut Bencher) {
     let mut data = vec![42.0; 2 * size];
     let plan = Plan::new(Operation::Forward, 2 * size);
+    bencher.bytes = size as u64;
     bencher.iter(|| black_box(dft::transform(&mut data, &plan)));
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -7,18 +7,28 @@ use dft::{Operation, Plan, c64};
 use test::{Bencher, black_box};
 
 #[bench] fn complex_0004(bencher: &mut Bencher) { complex(   4, bencher); }
+#[bench] fn complex_0008(bencher: &mut Bencher) { complex(   8, bencher); }
 #[bench] fn complex_0016(bencher: &mut Bencher) { complex(  16, bencher); }
+#[bench] fn complex_0032(bencher: &mut Bencher) { complex(  32, bencher); }
 #[bench] fn complex_0064(bencher: &mut Bencher) { complex(  64, bencher); }
+#[bench] fn complex_0128(bencher: &mut Bencher) { complex(  128, bencher); }
 #[bench] fn complex_0256(bencher: &mut Bencher) { complex( 256, bencher); }
+#[bench] fn complex_0512(bencher: &mut Bencher) { complex( 512, bencher); }
 #[bench] fn complex_1024(bencher: &mut Bencher) { complex(1024, bencher); }
+#[bench] fn complex_2048(bencher: &mut Bencher) { complex(2048, bencher); }
 #[bench] fn complex_4096(bencher: &mut Bencher) { complex(4096, bencher); }
 #[bench] fn complex_8192(bencher: &mut Bencher) { complex(8192, bencher); }
 
 #[bench] fn real_0004(bencher: &mut Bencher) { real(   4, bencher); }
+#[bench] fn real_0008(bencher: &mut Bencher) { real(   8, bencher); }
 #[bench] fn real_0016(bencher: &mut Bencher) { real(  16, bencher); }
+#[bench] fn real_0032(bencher: &mut Bencher) { real(  32, bencher); }
 #[bench] fn real_0064(bencher: &mut Bencher) { real(  64, bencher); }
+#[bench] fn real_0128(bencher: &mut Bencher) { real( 128, bencher); }
 #[bench] fn real_0256(bencher: &mut Bencher) { real( 256, bencher); }
+#[bench] fn real_0512(bencher: &mut Bencher) { real( 512, bencher); }
 #[bench] fn real_1024(bencher: &mut Bencher) { real(1024, bencher); }
+#[bench] fn real_2048(bencher: &mut Bencher) { real(2048, bencher); }
 #[bench] fn real_4096(bencher: &mut Bencher) { real(4096, bencher); }
 #[bench] fn real_8192(bencher: &mut Bencher) { real(8192, bencher); }
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -25,13 +25,13 @@ use test::{Bencher, black_box};
 fn complex(size: usize, bencher: &mut Bencher) {
     let mut data = vec![c64::new(42.0, 69.0); size];
     let plan = Plan::new(Operation::Forward, size);
-    bencher.bytes = size as u64;
+    bencher.bytes = data.len() as u64;
     bencher.iter(|| black_box(dft::transform(&mut data, &plan)));
 }
 
 fn real(size: usize, bencher: &mut Bencher) {
     let mut data = vec![42.0; 2 * size];
     let plan = Plan::new(Operation::Forward, 2 * size);
-    bencher.bytes = size as u64;
+    bencher.bytes = data.len() as u64;
     bencher.iter(|| black_box(dft::transform(&mut data, &plan)));
 }

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -34,9 +34,11 @@ fn calculate<T>(data: &mut [Complex<T>], n: usize, factors: &[Complex<T>]) where
         for mut i in 0..step {
             while i < n {
                 let j = i + step;
-                let product = factors[k] * data[j];
-                data[j] = data[i] - product;
-                data[i] = data[i] + product;
+                unsafe {
+                    let product = *factors.get_unchecked(k) * *data.get_unchecked(j);
+                    *data.get_unchecked_mut(j) = *data.get_unchecked(i) - product;
+                    *data.get_unchecked_mut(i) = *data.get_unchecked(i) + product;
+                }
                 i += jump;
             }
             k += 1;

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -66,7 +66,7 @@ fn rearrange<T>(data: &mut [Complex<T>], n: usize) {
 #[inline(always)]
 fn scale<T>(data: &mut [Complex<T>], n: usize) where T: Float {
     let factor = T::from(n).unwrap().recip();
-    for i in 0..n {
-        data[i] = data[i].scale(factor);
+    for value in data {
+        *value = value.scale(factor);
     }
 }


### PR DESCRIPTION
Hi,

Using unchecked indexing can provide some benefits for smaller DFT sizes.
Tested on:
Rust: rustc 1.14.0-nightly (cae6ab1c4 2016-11-05)
CPU: Core i7 4790k

"cargo test" after patch looks ok.

RUSTFLAGS="-Ctarget-cpu=native" cargo bench

BEFORE:
test complex_0004 ... bench:          14 ns/iter (+/- 13) = 285 MB/s
test complex_0016 ... bench:          66 ns/iter (+/- 1) = 242 MB/s
test complex_0064 ... bench:         330 ns/iter (+/- 1) = 193 MB/s
test complex_0256 ... bench:       1,652 ns/iter (+/- 10) = 154 MB/s
test complex_1024 ... bench:       7,813 ns/iter (+/- 15) = 131 MB/s
test complex_4096 ... bench:      83,019 ns/iter (+/- 5,384) = 49 MB/s
test complex_8192 ... bench:     211,867 ns/iter (+/- 1,209) = 38 MB/s
test real_0004    ... bench:          19 ns/iter (+/- 0) = 210 MB/s
test real_0016    ... bench:          91 ns/iter (+/- 4) = 175 MB/s
test real_0064    ... bench:         456 ns/iter (+/- 1) = 140 MB/s
test real_0256    ... bench:       2,170 ns/iter (+/- 4) = 117 MB/s
test real_1024    ... bench:      10,175 ns/iter (+/- 13) = 100 MB/s
test real_4096    ... bench:      90,446 ns/iter (+/- 1,128) = 45 MB/s
test real_8192    ... bench:     225,928 ns/iter (+/- 993) = 36 MB/s

AFTER:
test complex_0004 ... bench:          12 ns/iter (+/- 0) = 333 MB/s
test complex_0016 ... bench:          61 ns/iter (+/- 3) = 262 MB/s
test complex_0064 ... bench:         303 ns/iter (+/- 11) = 211 MB/s
test complex_0256 ... bench:       1,482 ns/iter (+/- 53) = 172 MB/s
test complex_1024 ... bench:       7,070 ns/iter (+/- 244) = 144 MB/s
test complex_4096 ... bench:      81,182 ns/iter (+/- 3,085) = 50 MB/s
test complex_8192 ... bench:     209,572 ns/iter (+/- 7,347) = 39 MB/s
test real_0004    ... bench:          22 ns/iter (+/- 9) = 181 MB/s
test real_0016    ... bench:          85 ns/iter (+/- 19) = 188 MB/s
test real_0064    ... bench:         429 ns/iter (+/- 48) = 149 MB/s
test real_0256    ... bench:       2,000 ns/iter (+/- 129) = 128 MB/s
test real_1024    ... bench:       8,816 ns/iter (+/- 610) = 116 MB/s
test real_4096    ... bench:      87,551 ns/iter (+/- 4,101) = 46 MB/s
test real_8192    ... bench:     224,766 ns/iter (+/- 1,103) = 36 MB/s

NOTE: "MB/s" for "real" tests are wrong. Already pushed commit fixing it.