### PR TITLE
Rust Nightly 1.23 breaks dft builds

### DIFF
--- a/src/real.rs
+++ b/src/real.rs
@@ -73,7 +73,7 @@ fn compose<T>(data: &mut [Complex<T>], n: usize, factors: &[Complex<T>], inverse
         return;
     }
     let m = factors.len();
-    let sign = if inverse { Complex::i() } else { -Complex::i() };
+    let sign : Complex<T> = if inverse { Complex::i() } else { -Complex::i() };
     for i in 1..h {
         let j = n - i;
         let part1 = data[i] + data[j].conj();


### PR DESCRIPTION
Rust Nightly 1.23 breaks dft builds. To remedy this I explicitly types a few variables which seems to have eliminated the issue. My guess is something changed about the way types are derived which made something unspecified. I believe this fix should be backwards compatible too.

This addresses issue #10 

Tests still run